### PR TITLE
ATTIC-240 activate publication

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
+---
+
+publish:
+  whoami: asf-site


### PR DESCRIPTION
IIUC, `output/` directory will be auto-detected as "Pelican output" https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#pelican-sub-directories-for-static-output

fine for me as a replacement to #1 